### PR TITLE
Tests to check exception raises on invalid params.

### DIFF
--- a/tests/test_metarna.py
+++ b/tests/test_metarna.py
@@ -20,3 +20,9 @@ class TestTargetScan(unittest.TestCase):
   def test_report(self):
     scan_res = scan(self.gene_seq, self.mirna_seq)
     pass
+
+  def test_invalid_gene_seq_raises_exception_(self):
+    self.assertRaises(ValueError, free_energy, "SomeInvalidGeneSequence", self.mirna_seq)
+  
+  def test_invalid_mirna_seq_raises_exception_(self):
+    self.assertRaises(ValueError, free_energy, self.gene_seq, "SomeInvalidmiRNASequence")


### PR DESCRIPTION
Passing invalid sequences should raise `ValueError`. Or not?

/cc @PrashntS @PragyaJaiswal 
